### PR TITLE
feat: Minio 설정 추가 및 CORS 설정 

### DIFF
--- a/src/main/java/com/java/ploud/config/MinioConfig.java
+++ b/src/main/java/com/java/ploud/config/MinioConfig.java
@@ -1,0 +1,27 @@
+package com.java.ploud.config;
+
+import io.minio.MinioClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+//minio 설정
+@Configuration
+public class MinioConfig {
+    @Value("${minio.endpoint}")
+    private String endpoint;
+    @Value("${minio.access-key}")
+    private String accessKey;
+    @Value("${minio.secret-key}")
+    private String secretKey;
+
+    @Bean
+    public MinioClient minioClient() {
+        return MinioClient.builder()
+                .endpoint(endpoint)
+                .credentials(accessKey, secretKey)
+                .build();
+    }
+}
+
+

--- a/src/main/java/com/java/ploud/config/WebConfig.java
+++ b/src/main/java/com/java/ploud/config/WebConfig.java
@@ -1,0 +1,25 @@
+package com.java.ploud.config;
+
+import org.jetbrains.annotations.NotNull;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig {
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(@NotNull CorsRegistry registry) {
+                registry.addMapping("/**") // 모든 엔드포인트
+                        .allowedOrigins("http://localhost:5173")
+                        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS") // 필요한 메서드
+                        .allowedHeaders("*")
+                        .allowCredentials(true); // 쿠키/인증정보 포함 허용 시
+            }
+        };
+    }
+
+}


### PR DESCRIPTION
---

# 변경 요약
<!-- 변경한 내용을 간단명료하게 적어 주세요. -->
- Minio 클라이언트 설정 클래스 추가 (`com.java.ploud.config.MinioConfig`)
- Web MVC CORS 설정 추가 (`com.java.ploud.config.WebConfig`)

---

# 변경 상세
<!-- 무엇을, 왜 변경했는지 상세히 작성 -->
- **MinioConfig**
  - `MinioClient` 빈 등록을 통해 Minio 연동 기본 설정 추가
  - application.properties / application.yml에서 `minio.endpoint`, `minio.access-key`, `minio.secret-key` 사용
- **WebConfig**
  - 모든 엔드포인트에 대해 CORS 매핑 추가
  - 허용 출처: `http://localhost:5173`
  - 허용 메서드: GET, POST, PUT, DELETE, OPTIONS
  - 허용 헤더: 모든 헤더, 쿠키/인증정보 포함 허용
