### PR TITLE
feat: 같은 dir의 파일을 조회하는 api

### DIFF
--- a/src/main/java/com/java/ploud/metadb/controller/FileController.java
+++ b/src/main/java/com/java/ploud/metadb/controller/FileController.java
@@ -26,9 +26,8 @@ public class FileController {
     @PostMapping
     public ResponseEntity<?> upload(
             @RequestParam("file") MultipartFile file,
-            @RequestParam(value = "ownerId", required = false) String ownerId,
-            @RequestParam(value = "group", required = false) String group) {
-
+            @RequestParam(value = "ownerId") String ownerId,
+            @RequestParam(value = "group") String group) {
         try {
             //스토리지
             ObjectWriteResponse upload = minioService.upload(file, ownerId, group);
@@ -40,5 +39,11 @@ public class FileController {
         } catch (Exception e) {
             return ResponseEntity.status(500).body("Upload failed: " + e.getMessage());
         }
+    }
+
+    @GetMapping
+    public ResponseEntity<?> readFiles(@RequestParam(value = "ownerId") String ownerId, Long dir) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(fileService.readFiles(dir));
     }
 }

--- a/src/main/java/com/java/ploud/metadb/service/FileService.java
+++ b/src/main/java/com/java/ploud/metadb/service/FileService.java
@@ -7,6 +7,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+
 @Slf4j
 @Service
 public class FileService {
@@ -30,4 +32,7 @@ public class FileService {
         return fileRepository.save(entity);
     }
 
+    public List<Files> readFiles(Long location) {
+        return fileRepository.findByParent_DirSeq(location);
+    }
 }

--- a/src/main/java/com/java/ploud/metadb/service/entity/Files.java
+++ b/src/main/java/com/java/ploud/metadb/service/entity/Files.java
@@ -39,4 +39,19 @@ public class Files {
     @CreatedDate
     @Column(name = "created_at")
     private LocalDateTime createdAt;
+
+    @Override
+    public String toString() {
+        return "Files{" + "\n" +
+                "fileSeq=" + fileSeq +"\n"+
+                ", ownerSeq='" + ownerSeq + "\n" +
+                ", storageKey='" + storageKey + "\n" +
+                ", title='" + title + "\n" +
+                ", originalFilename='" + originalFilename + "\n" +
+                ", size=" + size + "\n" +
+                ", contentType='" + contentType + "\n" +
+                ", parent=" + parent + "\n" +
+                ", createdAt=" + createdAt + "\n" +
+                '}';
+    }
 }

--- a/src/main/java/com/java/ploud/metadb/service/repository/FileRepository.java
+++ b/src/main/java/com/java/ploud/metadb/service/repository/FileRepository.java
@@ -3,5 +3,9 @@ package com.java.ploud.metadb.service.repository;
 import com.java.ploud.metadb.service.entity.Files;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface FileRepository extends JpaRepository<Files, Long> {
+    List<Files> findByParent_DirSeq(Long parent);
+
 }

--- a/src/test/java/com/java/ploud/metadb/service/FileServiceTest.java
+++ b/src/test/java/com/java/ploud/metadb/service/FileServiceTest.java
@@ -1,0 +1,23 @@
+package com.java.ploud.metadb.service;
+
+import com.java.ploud.metadb.service.entity.Files;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+@SpringBootTest
+class FileServiceTest {
+
+    @Autowired
+    private FileService fileService;
+
+    @Test
+    void test() {
+        List<Files> files = fileService.readFiles(1L);
+
+        System.out.println("files = " + files);
+    }
+
+}


### PR DESCRIPTION
---

# 변경 요약
<!-- 변경한 내용을 간단명료하게 적어 주세요. -->
- 같은 디렉토리를 부모로 갖는 파일 또는 디렉토리를 조회하기 위한 메서드
----

# 변경 상세
<!-- 무엇을, 왜 변경했는지 상세히 작성 -->
- FileService.readFile

    - 목적
        - 메타데이터 디비 내 같은 디렉토리의 파일 또는 디렉토리를 조회하기 위함
        - 현재 Dir 조회기능 없음